### PR TITLE
add missing section/priority for deb control files

### DIFF
--- a/debian/server-amd64
+++ b/debian/server-amd64
@@ -5,3 +5,5 @@ Description: Modded server for Minecraft Pi Edition
 Homepage: https://github.com/mobilegmYT/mcpi-reborn-extended/
 Architecture: amd64
 Depends: libc6, libstdc++6, libc6-armhf-cross, libstdc++6-armhf-cross, qemu-user, patchelf
+Section: games
+Priority: optional

--- a/debian/server-arm64
+++ b/debian/server-arm64
@@ -5,3 +5,5 @@ Description: Modded server for Minecraft Pi Edition
 Homepage: https://github.com/mobilegmYT/mcpi-reborn-extended/
 Architecture: arm64
 Depends: libc6, libstdc++6, libc6:armhf, libstdc++6:armhf, patchelf
+Section: games
+Priority: optional

--- a/debian/server-armhf
+++ b/debian/server-armhf
@@ -5,3 +5,5 @@ Description: Modded server for Minecraft Pi Edition
 Homepage: https://github.com/mobilegmYT/mcpi-reborn-extended/
 Architecture: armhf
 Depends: libc6, libstdc++6, patchelf
+Section: games
+Priority: optional


### PR DESCRIPTION
For some reason, the server debs don't have the required `Section` and `Priority` lines in their debian control files. This PR adds them.

Without these two entries, I can't add the packages to the afterburner package repo. If you could repackage the debs and replace the old ones on the latest release, that would be great.

Thanks!